### PR TITLE
Forgot a variable to rename

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -402,7 +402,7 @@ async def create_thread_channel(bot, recipient, category, overwrites, *, name=No
 
             if not fallback:
                 fallback = await category.clone(name="Fallback Modmail")
-                bot.config.set("fallback_category_id", str(category.id))
+                bot.config.set("fallback_category_id", str(fallback.id))
                 await bot.config.update()
 
             return await create_thread_channel(


### PR DESCRIPTION
When updating the config, the variable name was set to the main category and would update it as such.