### PR TITLE
Application commands development.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -330,15 +330,17 @@ class ModmailBot(commands.Bot):
 
     def _refresh_tree(self) -> None:
         """
-        Internal method to refresh the global application commands
-        stored in `Bot.tree` and add them into every guild.
-        This will not register the commands with discord. To do that,
+        Internal method to refresh the global application commands which were automatically
+        stored in `Bot.tree` on startup, and copy them into every guild.
+
+        This will not register the commands in the client. To do that,
         the `Bot.tree.sync()` needs to be called separately.
         """
-        all_cmds = self.tree.get_commands()
         for guild in self.guilds:
-            for cmd in all_cmds:
-                self.tree.add_command(cmd, guild=guild)
+            self.tree.copy_global_to(guild=guild)
+
+        # clear global commands from `Bot.tree`
+        self.tree.clear_commands(guild=None)
 
     async def get_prefix(self, message=None) -> List[str]:
         """

--- a/cogs/resources/guild.py
+++ b/cogs/resources/guild.py
@@ -11,31 +11,6 @@ if TYPE_CHECKING:
 
     from core.ext.commands import Context
 
-vc_regions = {
-    "vip-us-east": "__VIP__ US East " + "\U0001F1FA\U0001F1F8",
-    "vip-us-west": "__VIP__ US West " + "\U0001F1FA\U0001F1F8",
-    "vip-amsterdam": "__VIP__ Amsterdam " + "\U0001F1F3\U0001F1F1",
-    "eu-west": "EU West " + "\U0001F1EA\U0001F1FA",
-    "eu-central": "EU Central " + "\U0001F1EA\U0001F1FA",
-    "europe": "Europe " + "\U0001F1EA\U0001F1FA",
-    "london": "London " + "\U0001F1EC\U0001F1E7",
-    "frankfurt": "Frankfurt " + "\U0001F1E9\U0001F1EA",
-    "amsterdam": "Amsterdam " + "\U0001F1F3\U0001F1F1",
-    "us-west": "US West " + "\U0001F1FA\U0001F1F8",
-    "us-east": "US East " + "\U0001F1FA\U0001F1F8",
-    "us-south": "US South " + "\U0001F1FA\U0001F1F8",
-    "us-central": "US Central " + "\U0001F1FA\U0001F1F8",
-    "singapore": "Singapore " + "\U0001F1F8\U0001F1EC",
-    "sydney": "Sydney " + "\U0001F1E6\U0001F1FA",
-    "brazil": "Brazil " + "\U0001F1E7\U0001F1F7",
-    "hongkong": "Hong Kong " + "\U0001F1ED\U0001F1F0",
-    "russia": "Russia " + "\U0001F1F7\U0001F1FA",
-    "japan": "Japan " + "\U0001F1EF\U0001F1F5",
-    "southafrica": "South Africa " + "\U0001F1FF\U0001F1E6",
-    "india": "India " + "\U0001F1EE\U0001F1F3",
-    "dubai": "Dubai " + "\U0001F1E6\U0001F1EA",
-    "south-korea": "South Korea " + "\U0001f1f0\U0001f1f7",
-}
 verif = {
     "none": "0 - None",
     "low": "1 - Low",
@@ -112,10 +87,6 @@ class GuildResource:
             ),
         )
         embed.add_field(name="__Roles:__", value=f"{len(guild.roles)}")
-        embed.add_field(
-            name="__Server Region:__",
-            value=f"{vc_regions.get(str(guild.region)) or str(guild.region).upper()}",
-        )
         embed.add_field(
             name="__Verification Level:__",
             value=f"{(verif[str(guild.verification_level)])}",

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -48,7 +48,7 @@ class Stats(commands.Cog):
 
     # Bot
 
-    @commands.command()
+    @commands.hybrid_command()
     @checks.has_permissions(PermissionLevel.REGULAR)
     async def botinfo(self, ctx: commands.Context):
         """
@@ -145,7 +145,7 @@ class Stats(commands.Cog):
 
     # Server
 
-    @commands.command(aliases=["guildinfo"])
+    @commands.hybrid_command(aliases=["guildinfo"])
     @checks.has_permissions(PermissionLevel.REGULAR)
     async def serverinfo(self, ctx: commands.Context):
         """

--- a/plugins/@extension/developer/developer.py
+++ b/plugins/@extension/developer/developer.py
@@ -621,12 +621,10 @@ class Developer(commands.Cog):
 
     @app_command.command(name="sync")
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def ac_sync(
-        self, ctx: commands.Context, guild: Optional[str] = None
-    ):
+    async def ac_sync(self, ctx: commands.Context, guild: Optional[str] = None):
         """
         Sync application commands for specified guild.
-        
+
         For `guild` parameter, you may pass a guild ID, name or "global".
         If not passed, fallback to guild where the command is executed.
         """

--- a/plugins/@extension/developer/developer.py
+++ b/plugins/@extension/developer/developer.py
@@ -633,7 +633,7 @@ class Developer(commands.Cog):
         elif guild.lower() == "global":
             guild = None
         else:
-            conv = commands.GuildConverter
+            conv = commands.GuildConverter()
             argument = guild
             try:
                 guild = await conv.convert(ctx, argument)

--- a/plugins/@extension/developer/developer.py
+++ b/plugins/@extension/developer/developer.py
@@ -622,13 +622,25 @@ class Developer(commands.Cog):
     @app_command.command(name="sync")
     @checks.has_permissions(PermissionLevel.OWNER)
     async def ac_sync(
-        self, ctx: commands.Context, guild: Optional[discord.Guild] = None
+        self, ctx: commands.Context, guild: Optional[str] = None
     ):
         """
         Sync application commands for specified guild.
+        
+        For `guild` parameter, you may pass a guild ID, name or "global".
+        If not passed, fallback to guild where the command is executed.
         """
         if guild is None:
             guild = ctx.guild
+        elif guild.lower() == "global":
+            guild = None
+        else:
+            conv = commands.GuildConverter
+            argument = guild
+            try:
+                guild = await conv.convert(ctx, argument)
+            except commands.GuildNotFound:
+                raise commands.BadArgument(f'Guild "{argument}" not found.')
 
         guild_cmds = self.bot.tree.get_commands(guild=guild)
         for cmd in self.bot.tree.get_commands():

--- a/plugins/@extension/developer/developer.py
+++ b/plugins/@extension/developer/developer.py
@@ -695,7 +695,7 @@ class Developer(commands.Cog):
                 self.bot.tree.add_command(cmd, guild=guild)
         await self.bot.tree.sync(guild=guild)
         await ctx.send(
-            f'Successfully synched application commands for {str(guild) if guild else "global"}.'
+            f'Successfully synced application commands for {str(guild) if guild else "global"}.'
         )
 
 


### PR DESCRIPTION
- Refresh application commands from `Bot.tree` which were automatically added on startup, and copy them to every guild. The global commands then will be removed from `Bot.tree`.
- Update `ac sync` and `ac clear` commands.
- Add `botinfo` and `serverinfo` to application commands.
- Delete region mapping for guild in `cogs/resources/guild.py` as `Guild.region` is now deprecated.