### PR TITLE
Contact panel.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1637,11 +1637,11 @@ class ModmailBot(commands.Bot):
                 )
                 await interaction.followup.send(embed=embed, ephemeral=True)
 
-        modmai_thread = await self.thread_manager.find(recipient=member)
-        if modmai_thread:
+        modmail_thread = await self.thread_manager.find(recipient=member)
+        if modmail_thread:
             desc = "A thread for for you already exists"
-            if modmai_thread.channel:
-                desc += f" in {modmai_thread.channel.mention}"
+            if modmail_thread.channel:
+                desc += f" in {modmail_thread.channel.mention}"
             desc += "."
             embed = discord.Embed(color=self.error_color, description=desc)
             kwargs = {"embed": embed}
@@ -1653,10 +1653,10 @@ class ModmailBot(commands.Bot):
                 send_func = interaction.followup.send
             await send_func(**kwargs)
         else:
-            modmai_thread = await self.thread_manager.create(
+            modmail_thread = await self.thread_manager.create(
                 recipient=member, creator=member, category=None, manual_trigger=False
             )
-            if modmai_thread.cancelled:
+            if modmail_thread.cancelled:
                 return
 
             embed = discord.Embed(
@@ -1673,8 +1673,8 @@ class ModmailBot(commands.Bot):
                 description=f"Thread started by {member.mention}.",
                 color=self.main_color,
             )
-            await modmai_thread.wait_until_ready()
-            await modmai_thread.channel.send(embed=embed)
+            await modmail_thread.wait_until_ready()
+            await modmail_thread.channel.send(embed=embed)
 
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
         await asyncio.gather(

--- a/bot.py
+++ b/bot.py
@@ -1625,7 +1625,7 @@ class ModmailBot(commands.Bot):
                 send_func = member.send
             else:
                 kwargs["ephemeral"] = True
-                send_func = interaction.response.send_message
+                send_func = interaction.followup.send
             return await send_func(**kwargs)
 
         if await self.is_blocked(member):
@@ -1635,7 +1635,7 @@ class ModmailBot(commands.Bot):
                     color=self.error_color,
                     description=f"You are currently blocked from contacting {self.user.name}.",
                 )
-                await interaction.response.send_message(embed=embed, ephemeral=True)
+                await interaction.followup.send(embed=embed, ephemeral=True)
 
         modmai_thread = await self.thread_manager.find(recipient=member)
         if modmai_thread:
@@ -1650,7 +1650,7 @@ class ModmailBot(commands.Bot):
                 send_func = self.contact_panel.channel.send
             else:
                 kwargs["ephemeral"] = True
-                send_func = interaction.response.send_message
+                send_func = interaction.followup.send
             await send_func(**kwargs)
         else:
             modmai_thread = await self.thread_manager.create(

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1015,15 +1015,7 @@ class Modmail(commands.Cog):
         sent_emoji, _ = await self.bot.retrieve_emoji()
         await self.bot.add_reaction(ctx.message, sent_emoji)
 
-    @commands.command(
-        extras={
-            "param_descriptions": {
-                "user": "User to contact, may be a user ID, mention or name.",
-                "category": "The category to create the thread. If not specified, defaults to main category.",
-                "option": "Additional option, can be `silent` or `silently`.",
-            }
-        }
-    )
+    @commands.command()
     @checks.has_permissions(PermissionLevel.SUPPORTER)
     async def contact(
         self,
@@ -1092,8 +1084,9 @@ class Modmail(commands.Cog):
 
         else:
             if ctx.message:
-                manual_trigger = ctx.message.id != tryint(
-                    self.bot.config.get("react_to_contact_message")
+                manual_trigger = (
+                    f"{ctx.channel.id}-{ctx.message.id}"
+                    != self.bot.config.get("contact_panel_message")
                 )
             else:
                 manual_trigger = True

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -973,6 +973,7 @@ class Utility(commands.Cog):
         """Delete a set configuration variable."""
         keys = self.bot.config.public_keys
         if key in keys:
+            key = await self.bot.config.before_remove(key)
             self.bot.config.remove(key)
             await self.bot.config.update()
             embed = discord.Embed(

--- a/core/config.py
+++ b/core/config.py
@@ -20,6 +20,7 @@ from core.logging_ext import getLogger
 from core.models import Default
 from core.timeutils import UserFriendlyTime
 from core.utils import strtobool
+from core.views.contact import ContactView
 
 if TYPE_CHECKING:
     from bot import ModmailBot
@@ -100,6 +101,9 @@ class ConfigManager:
         # react to contact
         "react_to_contact_message": None,
         "react_to_contact_emoji": "📩",
+        "contact_message_panel": None,
+        "contact_button_label": "Contact",
+        "contact_button_emoji": "📩",
         # confirm thread creation
         "confirm_thread_creation": False,
         "confirm_thread_creation_title": "Confirm thread creation",
@@ -331,6 +335,18 @@ class ConfigManager:
                 )
             react_message_emoji = self.bot.config.get("react_to_contact_emoji")
             await self.bot.add_reaction(message, react_message_emoji)
+
+        if key == "contact_message_panel":
+            try:
+                message = await ctx.fetch_message(int(value))
+            except ValueError:
+                raise InvalidConfigError(f"Unable to convert `{value}` to int.")
+            except discord.NotFound:
+                raise InvalidConfigError(
+                    f"Message ID `{value}` can't be found in this channel."
+                )
+            await message.edit(view=ContactView(ctx.bot, message))
+            value = f"{message.channel.id}-{message.id}"
 
         if key == "mention":
             ids = list(v for v in value.split(" "))

--- a/core/config.py
+++ b/core/config.py
@@ -428,6 +428,12 @@ class ConfigManager:
 
         return self.__setitem__(key, item)
 
+    async def before_remove(self, key: str) -> str:
+        if key.lower() == "contact_panel_message":
+            await self.bot.contact_panel.stop()
+
+        return key
+
     def remove(self, key: str) -> Any:
         key = key.lower()
         logger.info("Removing %s.", key)

--- a/core/config.py
+++ b/core/config.py
@@ -332,7 +332,6 @@ class ConfigManager:
                 )
 
             await self.bot.contact_panel.setup(message)
-
             value = f"{message.channel.id}-{message.id}"
 
         if key == "mention":

--- a/core/config.py
+++ b/core/config.py
@@ -20,7 +20,6 @@ from core.logging_ext import getLogger
 from core.models import Default
 from core.timeutils import UserFriendlyTime
 from core.utils import strtobool
-from core.views.contact import ContactView
 
 if TYPE_CHECKING:
     from bot import ModmailBot
@@ -319,7 +318,7 @@ class ConfigManager:
 
     async def before_set(self, ctx: Context, key: str, value: VT) -> Optional[str, VT]:
         """
-        A method for any additional coro task/check that must be done before setting up the value for
+        A method for additional coro tasks/checks that must be done before setting up the value for
         `config set` command.
         """
         if key == "contact_panel_message":
@@ -332,11 +331,7 @@ class ConfigManager:
                     f"```py\n{type(exc).__name__}: {str(exc)}\n```"
                 )
 
-            if message.author.id != self.bot.user.id:
-                emoji = self.bot.config.get("contact_button_emoji")
-                await self.bot.add_reaction(message, emoji)
-            else:
-                await message.edit(view=ContactView(ctx.bot, message))
+            await self.bot.contact_panel.setup(message)
 
             value = f"{message.channel.id}-{message.id}"
 

--- a/core/config_help.json
+++ b/core/config_help.json
@@ -568,24 +568,36 @@
     ],
     "image": "https://i.imgur.com/SKOC42Z.png"
   },
-  "react_to_contact_message": {
+  "contact_panel_message": {
     "default": "None",
-    "description": "A message ID where reactions are tracked. If the `react_to_contact_emoji` is added, the bot opens a thread with them.",
+    "description": "A message ID where interactions or reactions are tracked. When the interaction or reaction is made, the bot opens a thread with them.",
     "examples": [
-      "`{prefix}config set react_to_contact_message 773575608814534717`"
+      "`{prefix}config set contact_panel_message 773575608814534717`",
+      "`{prefix}config set contact_panel_message 923493258231245678-773575608814534717`"
     ],
     "notes": [
-      "See also: `react_to_contact_emoji`."
+      "This depends on the author of the message. If the message author is other than the bot, then reaction will be used. Otherwise, button.",
+      "See also: `contact_button_label`, `contact_button_emoji`"
     ]
   },
-  "react_to_contact_emoji": {
-    "default": "\uD83D\uDCE9",
-    "description": "An emoji which is tracked in `react_to_contact_message`",
+  "contact_button_label": {
+    "default": "Contact",
+    "description": "A label which is shown on the contact button.",
     "examples": [
-      "`{prefix}config set react_to_contact_emoji \u2705`"
+      "`{prefix}config set contact_button_label DM Modmail`"
     ],
     "notes": [
-      "See also: `react_to_contact_message`."
+      "See also: `contact_panel_message`, `contact_button_emoji`"
+    ]
+  },
+  "contact_button_emoji": {
+    "default": "\uD83D\uDCE9",
+    "description": "An emoji which is tracked in `contact_panel_message` reactions, or shown on the contact button.",
+    "examples": [
+      "`{prefix}config set contact_button_emoji \u2705`"
+    ],
+    "notes": [
+      "See also: `contact_panel_message`, `contact_button_label`"
     ]
   },
   "confirm_button_accept": {

--- a/core/views/contact.py
+++ b/core/views/contact.py
@@ -65,17 +65,12 @@ class ContactView(View):
         self.bot: ModmailBot = bot
         super().__init__(timeout=None)
 
-        self.channel_id: int = MISSING
-        self.message_id: int = MISSING
-
         if message:
-            self.channel_id = message.channel.id
-            self.message_id = message.id
             payload: ContactButtonPayload = {
                 "label": self.bot.config["contact_button_label"],
                 "emoji": self._resolve_emoji(self.bot.config["contact_button_emoji"]),
                 "style": ButtonStyle.grey,
-                "custom_id": f"contactbutton-{self.bot.user.id}-{self.channel_id}-{self.message_id}",
+                "custom_id": f"contactbutton-{self.bot.user.id}-{message.channel.id}-{message.id}",
             }
             self.add_item(ContactButton(payload))
 

--- a/core/views/contact.py
+++ b/core/views/contact.py
@@ -105,7 +105,7 @@ class ContactView(View):
         Stops listening to interactions made on this view and removes the view from the message.
         """
         self.stop()
-        
+
         message = self.bot.contact_panel.message
         if message:
             try:

--- a/core/views/contact.py
+++ b/core/views/contact.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
-import asyncio
 import re
 
-from typing import Optional, Tuple, Union, TYPE_CHECKING
+from typing import List, Optional, Tuple, TypedDict, Union, TYPE_CHECKING
 
 import discord
 from discord import ButtonStyle, Interaction
 from discord.ui import Button, View
 from emoji import UNICODE_EMOJI_ENGLISH
 
-from core.enums_ext import DMDisabled
-
 
 if TYPE_CHECKING:
     from bot import ModmailBot
+
+    class ContactButtonPayload(TypedDict):
+        label: str
+        emoji: str
+        style: ButtonStyle
+        custom_id: str
+
 
 MISSING = discord.utils.MISSING
 
@@ -24,22 +28,27 @@ class ContactButton(Button["ContactView"]):
     The contact button.
     """
 
-    def __init__(self, item):
+    def __init__(self, payload: ContactButtonPayload):
         super().__init__(
-            label=item["label"],
-            emoji=item["emoji"],
+            label=payload["label"],
+            emoji=payload["emoji"],
             style=ButtonStyle.grey,
-            custom_id=item["custom_id"],
+            custom_id=payload["custom_id"],
         )
 
     async def callback(self, interaction: Interaction):
         assert self.view is not None
+        # TODO: Do contact Modmail here
+        await self.view.bot.handle_contact_panel_events(interaction=interaction)
         await interaction.response.send_message("Done", ephemeral=True)
 
 
 class ContactView(View):
     """
     Represents a persistent view for contact panel.
+
+    This view can only be added to the bot's message (discord limitation)
+    and in the main guild.
 
     Parameters
     -----------
@@ -50,34 +59,46 @@ class ContactView(View):
 
     """
 
+    children: List[ContactButton]
+
     def __init__(self, bot: ModmailBot, message: discord.Message = MISSING):
         self.bot: ModmailBot = bot
         super().__init__(timeout=None)
 
+        self.channel_id: int = MISSING
+        self.message_id: int = MISSING
+
         if message:
-            item = {
+            self.channel_id = message.channel.id
+            self.message_id = message.id
+            payload: ContactButtonPayload = {
                 "label": self.bot.config["contact_button_label"],
                 "emoji": self._resolve_emoji(self.bot.config["contact_button_emoji"]),
                 "style": ButtonStyle.grey,
-                "custom_id": f"contactbutton-{self.bot.user.id}-{message.channel.id}-{message.id}",
+                "custom_id": f"contactbutton-{self.bot.user.id}-{self.channel_id}-{self.message_id}",
             }
-            self.add_item(ContactButton(item))
+            self.add_item(ContactButton(payload))
         else:
             # this is for startup event
-            # TODO: check whether this can be completely ommited
             self._setup_persistent()
+
+        self.bot.contact_panel_view = self
 
     def _setup_persistent(self) -> None:
         channel_id, message_id = self._resolve_ids()
         if not channel_id or not message_id:
             return
-        item = {
+
+        self.channel_id = channel_id
+        self.message_id = message_id
+
+        payload: ContactButtonPayload = {
             "label": self.bot.config["contact_button_label"],
             "emoji": self._resolve_emoji(self.bot.config["contact_button_emoji"]),
             "style": ButtonStyle.grey,
-            "custom_id": f"contactbutton-{self.bot.user.id}-{channel_id}-{message_id}",
+            "custom_id": f"contactbutton-{self.bot.user.id}-{self.channel_id}-{self.message_id}",
         }
-        self.add_item(ContactButton(item))
+        self.add_item(ContactButton(payload))
 
     def _resolve_emoji(
         self, name: Optional[str]
@@ -121,19 +142,19 @@ class ContactView(View):
     async def interaction_check(self, interaction: Interaction) -> bool:
         if interaction.user.bot:
             return False
-        # TODO: Check if user is blocked
-        if self.bot.config["dm_disabled"] in (
-            DMDisabled.NEW_THREADS,
-            DMDisabled.ALL_THREADS,
-        ):
-            embed = discord.Embed(
-                color=self.bot.error_color,
-                description=self.bot.config["disabled_new_thread_response"],
-            )
-            embed.set_footer(
-                text=self.bot.config["disabled_new_thread_footer"],
-                icon_url=self.bot.guild.icon.url,
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return False
+
+        # TODO: Cooldown check to prevent spam.
+
         return self.bot.guild.get_member(interaction.user.id) is not None
+
+    async def force_stop(self) -> None:
+        """
+        Stops listening to interactions made on this view and removes the view from the message.
+        """
+        self.stop()
+
+        if self.channel_id and self.message_id:
+            channel = self.bot.guild.get_channel(self.channel_id)
+            if channel is not None:
+                message = await channel.fetch_message(self.message_id)
+                await message.edit(view=None)

--- a/core/views/contact.py
+++ b/core/views/contact.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import asyncio
+import re
+
+from typing import Optional, Union, TYPE_CHECKING
+
+import discord
+from discord import ButtonStyle, Interaction
+from discord.ui import Button, View
+from emoji import UNICODE_EMOJI_ENGLISH
+
+from core.logging_ext import getLogger
+
+
+if TYPE_CHECKING:
+    from bot import ModmailBot
+
+MISSING = discord.utils.MISSING
+
+logger = getLogger(__name__)
+
+
+class ContactButton(Button["ContactView"]):
+    """
+    The contact button.
+    """
+
+    def __init__(self, item):
+        super().__init__(
+            label=item["label"],
+            emoji=item["emoji"],
+            style=ButtonStyle.grey,
+            custom_id=item["custom_id"],
+        )
+
+    async def callback(self, interaction: Interaction):
+        assert self.view is not None
+        pass
+
+
+class ContactView(View):
+    """
+    Represents press to contact persistent view.
+
+    Parameters
+    -----------
+    bot : ModmailBot
+        The Modmail bot.
+    message : discord.Message
+        The message object containing the view the bot listens to.
+
+    """
+
+    def __init__(self, bot: ModmailBot, message: discord.Message = MISSING):
+        self.bot: ModmailBot = bot
+        self.message: discord.Message = message
+        super().__init__(timeout=None)
+
+        asyncio.create_task(self.initialize())
+
+    async def initialize(self) -> None:
+        if self.message is MISSING:
+            message = await self.fetch_contact_message()
+            if message is None:
+                return
+            self.message = message
+
+        item = {
+            "label": self.bot.config["contact_button_label"],
+            "emoji": self._resolve_emoji(self.bot.config["contact_button_emoji"]),
+            "style": ButtonStyle.grey,
+            "custom_id": f"contactbutton-{self.bot.user.id}-{self.message.channel.id}-{self.message.id}",
+        }
+        self.add_item(ContactButton(item))
+        await self.message.edit(view=self)
+
+    def _resolve_emoji(
+        self, name: Optional[str]
+    ) -> Optional[Union[discord.PartialEmoji, discord.Emoji, str]]:
+        if name is None:
+            return None
+
+        name = re.sub("\ufe0f", "", name)
+        emoji = discord.PartialEmoji.from_str(name)
+        if emoji.is_unicode_emoji():
+            if emoji.name not in UNICODE_EMOJI_ENGLISH:
+                emoji = None
+        else:
+            # custom emoji
+            emoji = self.bot.get_emoji(emoji.id)
+
+        if emoji is None:
+            raise ValueError(f'Emoji "{name}" not found.')
+
+        return emoji
+
+    async def fetch_contact_message(self) -> Optional[discord.Message]:
+        id_string = self.bot.config.get["contact_message_panel"]
+        if id_string is None:
+            return None
+
+        # copied from discord.py PartialMessageConverter._get_id_matches
+        id_regex = re.compile(
+            r"(?P<channel_id>[0-9]{15,20})-(?P<message_id>[0-9]{15,20})$"
+        )
+        match = id_regex.match(id_string)
+        if match is None:
+            return None
+
+        data = match.groupdict()
+        # only get from main guild
+        channel = self.bot.guild.get_channel(int(data["channel_id"]))
+        if channel is None:
+            return None
+
+        try:
+            message = await channel.fetch_message(int(data["message_id"]))
+        except discord.NotFound:
+            logger.error(f'Contact message "{id_string}" not found.')
+            return None
+
+        return message
+
+    async def interaction_check(self, interaction: Interaction) -> bool:
+        if self.message is MISSING or interaction.user.bot:
+            return False
+        # TODO: Check if user is blocked
+        return self.message.guild.get_member(interactin.user.id) is not None

--- a/core/views/contact.py
+++ b/core/views/contact.py
@@ -38,8 +38,8 @@ class ContactButton(Button["ContactView"]):
 
     async def callback(self, interaction: Interaction):
         assert self.view is not None
-        await self.view.bot.handle_contact_panel_events(interaction=interaction)
         await interaction.response.defer()
+        await self.view.bot.handle_contact_panel_events(interaction=interaction)
 
 
 class ContactView(View):
@@ -98,7 +98,6 @@ class ContactView(View):
             return False
 
         # TODO: Cooldown check to prevent spam.
-
         return self.bot.guild.get_member(interaction.user.id) is not None
 
     async def force_stop(self) -> None:
@@ -106,9 +105,11 @@ class ContactView(View):
         Stops listening to interactions made on this view and removes the view from the message.
         """
         self.stop()
-
-        if self.channel_id and self.message_id:
-            channel = self.bot.guild.get_channel(self.channel_id)
-            if channel is not None:
-                message = await channel.fetch_message(self.message_id)
+        
+        message = self.bot.contact_panel.message
+        if message:
+            try:
                 await message.edit(view=None)
+            except discord.HTTPException:
+                # just supress this
+                return

--- a/core/views/contact.py
+++ b/core/views/contact.py
@@ -38,7 +38,6 @@ class ContactButton(Button["ContactView"]):
 
     async def callback(self, interaction: Interaction):
         assert self.view is not None
-        # TODO: Do contact Modmail here
         await self.view.bot.handle_contact_panel_events(interaction=interaction)
         await interaction.response.defer()
 


### PR DESCRIPTION
Contacting Modmail now uses button.

However, there is a gotcha with this feature due to discord limitation, where the bot is not allowed to add buttons on other than its messages, unlike emojis/reactions.

__**Changes:**__
- Add a new class `ContactView`.
- Add a new class `ContactPanel`.
- Add `contact_panel` attribute for the bot.
- Remove `.handle_react_to_contact` method in favor of the new `.handle_contact_panel_events` method. This new method will handle both reactions and button interactions on the contact panel message events. It also checks for blocked users (and more) before creating the thread.
- Add `contact_panel_message`, `contact_button_label` and `contact_button_emoji` config options.
- Remove `react_to_contact_message` and `react_to_contact_emoji` config options in favor of `contact_panel_message` and `contact_button_emoji`.
- Update config option docs.
- Automatically add/remove button (bot's message) or reaction emoji when setting or removing the `contact_panel_message`.